### PR TITLE
Add 9 knowledge articles for transformers, agents, and local-inference

### DIFF
--- a/topics/agents/agent-architectures.md
+++ b/topics/agents/agent-architectures.md
@@ -1,0 +1,240 @@
+---
+id: kb-2025-007
+title: "LLM Agent Architectures and Patterns"
+created: 2025-02-10
+updated: 2025-02-10
+
+author: human
+curation_type: ai_assisted
+
+sources:
+  - id: src-001
+    type: primary
+    title: "ReAct: Synergizing Reasoning and Acting in Language Models"
+    authors: ["Yao et al."]
+    url: "https://arxiv.org/abs/2210.03629"
+    accessed: 2025-02-10
+    published: 2022-10-06
+    quotes:
+      - text: "We explore the use of LLMs to generate both reasoning traces and task-specific actions in an interleaved manner, allowing for greater synergy between the two."
+        location: "Abstract"
+      - text: "ReAct prompts LLMs to generate both verbal reasoning traces and actions pertaining to a task in an interleaved manner, which allows the model to perform dynamic reasoning to create, maintain, and adjust high-level plans for acting."
+        location: "Section 1 - Introduction"
+
+  - id: src-002
+    type: primary
+    title: "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models"
+    authors: ["Wei et al."]
+    url: "https://arxiv.org/abs/2201.11903"
+    accessed: 2025-02-10
+    published: 2022-01-28
+    quotes:
+      - text: "We explore how generating a chain of thought — a series of intermediate reasoning steps — significantly improves the ability of large language models to perform complex reasoning."
+        location: "Abstract"
+
+  - id: src-003
+    type: primary
+    title: "A Survey on Large Language Model based Autonomous Agents"
+    authors: ["Wang et al."]
+    url: "https://arxiv.org/abs/2308.11432"
+    accessed: 2025-02-10
+    published: 2023-08-22
+    quotes:
+      - text: "The key characteristics of agents can be summarized as: autonomy, reactivity, pro-activeness, and social ability."
+        location: "Section 2.1 - Origin of AI Agents"
+
+  - id: src-004
+    type: primary
+    title: "Reflexion: Language Agents with Verbal Reinforcement Learning"
+    authors: ["Shinn et al."]
+    url: "https://arxiv.org/abs/2303.11366"
+    accessed: 2025-02-10
+    published: 2023-03-20
+    quotes:
+      - text: "Reflexion agents verbally reflect on task feedback signals, then maintain their own reflective text in an episodic memory buffer to induce better decision-making in subsequent trials."
+        location: "Abstract"
+
+  - id: src-005
+    type: primary
+    title: "Tree of Thoughts: Deliberate Problem Solving with Large Language Models"
+    authors: ["Yao et al."]
+    url: "https://arxiv.org/abs/2305.10601"
+    accessed: 2025-02-10
+    published: 2023-05-17
+    quotes:
+      - text: "We introduce a new framework for language model inference, Tree of Thoughts (ToT), which generalizes over the popular Chain of Thought approach to prompting language models, and enables exploration over coherent units of text (thoughts) that serve as intermediate steps toward problem solving."
+        location: "Abstract"
+
+topics:
+  - agents
+  - architectures
+  - reasoning
+  - ai-fundamentals
+
+confidence: high
+verified: false
+verified_by: unverified
+verification_notes: "AI-assisted draft; quotes sourced from papers but need human verification against originals"
+
+ai_metadata:
+  model: claude-opus-4-6
+  generation_date: 2025-02-10
+  reviewed_by: pending
+---
+
+# LLM Agent Architectures and Patterns
+
+## Overview
+
+An LLM agent is a system where a language model operates in a loop, taking actions, observing results, and deciding what to do next. The key characteristics of agents are "autonomy, reactivity, pro-activeness, and social ability" [src-003]. This distinguishes agents from single-shot LLM calls: an agent persists, plans, acts, and adapts.
+
+## The Core Agent Loop
+
+At its simplest, every LLM agent follows the same pattern:
+
+```
+while not done:
+    observation = perceive(environment)
+    thought = reason(observation, memory, goal)
+    action = decide(thought)
+    result = execute(action)
+    memory = update(memory, result)
+```
+
+The variations between agent architectures are really about how they implement `reason`, `decide`, and `memory`. Everything else is plumbing.
+
+## Reasoning Patterns
+
+### Chain-of-Thought (CoT)
+
+Wei et al. showed that "generating a chain of thought — a series of intermediate reasoning steps — significantly improves the ability of large language models to perform complex reasoning" [src-002].
+
+CoT is the simplest reasoning pattern: instead of jumping to an answer, the model writes out its reasoning step by step. This works because:
+- It decomposes complex problems into manageable sub-steps
+- Each step is more likely to be correct than a single large leap
+- The written reasoning becomes context for subsequent steps
+
+CoT is a **prompting technique**, not an architecture, but it's foundational to every agent pattern that follows.
+
+### ReAct (Reason + Act)
+
+ReAct interleaves reasoning and action in a single stream. Yao et al. "explore the use of LLMs to generate both reasoning traces and task-specific actions in an interleaved manner" [src-001].
+
+A ReAct trace looks like:
+
+```
+Thought: I need to find who directed Inception.
+Action: search("Inception director")
+Observation: Christopher Nolan directed Inception (2010).
+Thought: The answer is Christopher Nolan.
+Action: finish("Christopher Nolan")
+```
+
+The key insight is that "ReAct prompts LLMs to generate both verbal reasoning traces and actions pertaining to a task in an interleaved manner, which allows the model to perform dynamic reasoning to create, maintain, and adjust high-level plans for acting" [src-001].
+
+**Why it works**: Reasoning without acting (pure CoT) can hallucinate facts. Acting without reasoning (direct tool use) can be unfocused. ReAct combines the grounding of real observations with the planning of explicit reasoning.
+
+**Limitation**: ReAct is fundamentally linear — it follows one chain of thought. If it goes down a wrong path, it may not recover.
+
+### Tree of Thoughts (ToT)
+
+ToT generalizes CoT from a single chain to a tree: "exploration over coherent units of text (thoughts) that serve as intermediate steps toward problem solving" [src-005].
+
+Instead of committing to one reasoning path, ToT:
+1. Generates multiple candidate next-steps
+2. Evaluates each candidate
+3. Explores the most promising paths (via BFS or DFS)
+4. Can backtrack from dead ends
+
+This is more powerful but significantly more expensive — each branch requires LLM calls. Best suited for problems with clear evaluation criteria (math, puzzles, constrained planning).
+
+### Reflexion
+
+Reflexion adds self-critique and memory across attempts. Agents "verbally reflect on task feedback signals, then maintain their own reflective text in an episodic memory buffer to induce better decision-making in subsequent trials" [src-004].
+
+The pattern:
+1. Attempt a task
+2. Observe failure (or suboptimal result)
+3. Reflect: "What went wrong? What should I do differently?"
+4. Store the reflection in memory
+5. Re-attempt with the reflection as additional context
+
+This is essentially verbal reinforcement learning — the agent learns from its mistakes within a session without any weight updates.
+
+## Planning Patterns
+
+### Plan-then-Execute
+
+The simplest planning approach: generate a full plan upfront, then execute each step. Works well for straightforward tasks but is brittle — if the plan is wrong, the agent follows it off a cliff.
+
+```
+Plan:
+1. Read the configuration file
+2. Find the database connection string
+3. Update the port number
+4. Write the file back
+
+Execute steps 1-4 sequentially.
+```
+
+### Iterative Refinement
+
+Generate an initial plan, start executing, and revise the plan as new information emerges. More robust than plan-then-execute because the agent adapts, but requires the model to manage the cognitive overhead of tracking plan state.
+
+### Hierarchical Planning
+
+Decompose a high-level goal into sub-goals, and sub-goals into concrete actions. Common in complex coding agents where a feature request decomposes into: understand requirements → identify files → plan changes → implement → test.
+
+## Memory Architectures
+
+Agents need memory beyond the current context window. Common approaches:
+
+### Context Window as Working Memory
+
+The simplest approach: everything the agent has seen is in the prompt. Works until you hit context limits. Most production agents start here.
+
+### Summarized/Compressed Memory
+
+Periodically summarize older context to fit more history into the window. Lossy but practical. The agent maintains a "running summary" of what it's done.
+
+### External Memory (RAG-style)
+
+Store observations, reflections, and results in a vector store or structured database. Retrieve relevant memories when needed. Scales beyond context limits but adds latency and retrieval noise.
+
+### Episodic Memory
+
+Store specific experiences (like Reflexion's reflections) as discrete episodes that can be recalled. This is closer to how humans learn from specific past events.
+
+## Practical Considerations
+
+### When to Use an Agent vs. a Single Call
+
+Not everything needs an agent. Use a single LLM call when:
+- The task is self-contained (no external information needed)
+- The output format is well-defined
+- No iteration or correction is needed
+
+Use an agent when:
+- The task requires multiple steps with real-world interaction
+- The model needs to gather information before answering
+- The task may require course correction based on intermediate results
+- Tool use is required (see [Tool Use and Function Calling](tool-use-function-calling.md))
+
+### The Cost of Agency
+
+Each agent step is an LLM call. A 10-step agent trajectory costs 10x a single call. More sophisticated patterns (ToT, Reflexion) multiply this further. The tradeoff is always: autonomy and robustness vs. cost and latency.
+
+### Failure Modes
+
+- **Looping**: The agent repeats the same action without progress
+- **Goal drift**: The agent loses track of the original objective over long trajectories
+- **Over-planning**: Spending more tokens planning than executing
+- **Hallucinated actions**: Attempting to call tools that don't exist or with wrong parameters
+
+## Further Reading
+
+- [ReAct Paper](https://arxiv.org/abs/2210.03629) - Reasoning + Acting [src-001]
+- [Chain-of-Thought Paper](https://arxiv.org/abs/2201.11903) - Foundation for agent reasoning [src-002]
+- [Agent Survey](https://arxiv.org/abs/2308.11432) - Comprehensive overview [src-003]
+- [Tool Use and Function Calling](tool-use-function-calling.md) - How agents interact with the world
+- [Multi-Agent Systems](multi-agent-systems.md) - When one agent isn't enough

--- a/topics/agents/multi-agent-systems.md
+++ b/topics/agents/multi-agent-systems.md
@@ -1,0 +1,207 @@
+---
+id: kb-2025-009
+title: "Multi-Agent Systems"
+created: 2025-02-10
+updated: 2025-02-10
+
+author: human
+curation_type: ai_assisted
+
+sources:
+  - id: src-001
+    type: primary
+    title: "AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation"
+    authors: ["Wu et al."]
+    url: "https://arxiv.org/abs/2308.08155"
+    accessed: 2025-02-10
+    published: 2023-08-16
+    quotes:
+      - text: "AutoGen is an open-source framework that allows developers to build LLM applications via multiple agents that can converse with each other to accomplish tasks."
+        location: "Abstract"
+      - text: "AutoGen agents are customizable, conversable, and can operate in various modes that employ combinations of LLMs, human inputs, and tools."
+        location: "Abstract"
+
+  - id: src-002
+    type: primary
+    title: "Communicative Agents for Software Development"
+    authors: ["Qian et al."]
+    url: "https://arxiv.org/abs/2307.07924"
+    accessed: 2025-02-10
+    published: 2023-07-16
+    quotes:
+      - text: "We present ChatDev, a virtual chat-powered software development company that mirrors the classic waterfall model, segmenting the development process into four chronological stages: designing, coding, testing, and documenting."
+        location: "Abstract"
+
+  - id: src-003
+    type: primary
+    title: "CrewAI Documentation"
+    url: "https://docs.crewai.com/"
+    accessed: 2025-02-10
+    quotes:
+      - text: "CrewAI is a framework for orchestrating role-playing autonomous AI agents."
+        location: "Introduction"
+
+  - id: src-004
+    type: primary
+    title: "Scaling LLM-Based Multi-Agent Systems"
+    authors: ["Chen et al."]
+    url: "https://arxiv.org/abs/2309.02427"
+    accessed: 2025-02-10
+    published: 2023-09-05
+
+  - id: src-005
+    type: primary
+    title: "More Agents Is All You Need"
+    authors: ["Li et al."]
+    url: "https://arxiv.org/abs/2402.05120"
+    accessed: 2025-02-10
+    published: 2024-02-07
+    quotes:
+      - text: "We find that, simply scaling the number of instantiated LLM agents and having them vote on their generated outputs can consistently improve performance across diverse tasks."
+        location: "Abstract"
+
+topics:
+  - agents
+  - multi-agent
+  - coordination
+  - ai-fundamentals
+
+confidence: high
+verified: false
+verified_by: unverified
+verification_notes: "AI-assisted draft; quotes sourced from papers and docs but need human verification"
+
+ai_metadata:
+  model: claude-opus-4-6
+  generation_date: 2025-02-10
+  reviewed_by: pending
+---
+
+# Multi-Agent Systems
+
+## Overview
+
+Multi-agent systems use multiple LLM-powered agents that communicate and collaborate to accomplish tasks. Instead of a single model doing everything, work is distributed across specialized agents with different roles, tools, and perspectives.
+
+The question is always: when does the added complexity of multiple agents actually help, versus when is a single capable agent sufficient?
+
+## Why Multiple Agents?
+
+### Specialization
+
+Different agents can have different system prompts, tools, and context. A "researcher" agent has web search tools; a "coder" agent has file editing tools; a "reviewer" agent has testing tools. Each agent is optimized for its role rather than trying to be good at everything.
+
+### Separation of Concerns
+
+Long, complex tasks can overwhelm a single agent's context window and coherence. Splitting into sub-tasks with separate agents keeps each context focused. The "planner" agent doesn't need to carry the full codebase in context — it just needs the high-level structure.
+
+### Debate and Verification
+
+Multiple agents can check each other's work. An agent that generates code and a separate agent that reviews it will catch errors that a single self-reviewing agent might miss, because each brings a fresh perspective to the problem.
+
+### Ensemble / Voting
+
+Li et al. found that "simply scaling the number of instantiated LLM agents and having them vote on their generated outputs can consistently improve performance across diverse tasks" [src-005]. Multiple independent attempts with majority voting is a brute-force but effective quality improvement.
+
+## Coordination Patterns
+
+### Conversation-Based (AutoGen)
+
+AutoGen models multi-agent interaction as conversations. "AutoGen agents are customizable, conversable, and can operate in various modes that employ combinations of LLMs, human inputs, and tools" [src-001].
+
+Agents communicate through messages, and conversation flow can be:
+- **Two-agent chat**: Back-and-forth between two agents (e.g., coder and reviewer)
+- **Group chat**: Multiple agents in a shared conversation with a manager agent directing who speaks next
+- **Nested chat**: An agent can internally spawn a sub-conversation with other agents
+
+### Role-Based Pipeline (ChatDev)
+
+ChatDev mirrors real software development by "segmenting the development process into four chronological stages: designing, coding, testing, and documenting" [src-002]. Different agent pairs handle each stage:
+
+- CEO + CTO: requirements → design
+- CTO + Programmer: design → code
+- Programmer + Tester: code → tested code
+- CEO + Reviewer: tested code → documented release
+
+This is essentially a **pipeline** — each stage's output becomes the next stage's input. Simple, predictable, but rigid.
+
+### Orchestrator Pattern
+
+A central "orchestrator" agent receives the task, plans sub-tasks, delegates to specialist agents, aggregates results, and produces the final output. The orchestrator is the only agent that sees the full picture; workers have narrow, focused contexts.
+
+```
+Orchestrator
+├── delegates to → Research Agent
+├── delegates to → Coding Agent
+├── delegates to → Testing Agent
+└── aggregates results → Final output
+```
+
+### Hierarchical
+
+Generalization of the orchestrator pattern with multiple levels. A top-level planner delegates to mid-level coordinators, who delegate to worker agents. Useful for very complex tasks but hard to debug.
+
+### Peer-to-Peer
+
+Agents communicate directly with each other without a central coordinator. More flexible but harder to control. Can lead to circular conversations or agents talking past each other.
+
+## Frameworks
+
+### AutoGen (Microsoft)
+
+"An open-source framework that allows developers to build LLM applications via multiple agents that can converse with each other to accomplish tasks" [src-001]. Conversation-first design, supports human-in-the-loop, flexible agent definitions. Now evolved into AutoGen 0.4+ with an event-driven architecture.
+
+### CrewAI
+
+"A framework for orchestrating role-playing autonomous AI agents" [src-003]. Emphasizes role definitions, goals, and backstories for each agent. Simpler API than AutoGen, more opinionated about the role-based pattern. Popular for its ease of use.
+
+### LangGraph
+
+Part of the LangChain ecosystem. Models agent workflows as graphs (state machines) with nodes as actions and edges as transitions. More explicit control flow than conversation-based approaches. Good for workflows that need deterministic structure with LLM-powered nodes.
+
+### Claude Code Sub-Agents
+
+Claude Code uses a practical multi-agent pattern internally: the main agent can spawn specialized sub-agents (Explore, Plan, Bash, etc.) for specific tasks. Each sub-agent has a constrained tool set and focused context. Results flow back to the main agent, which maintains the overall conversation.
+
+## When Multi-Agent Helps (and When It Doesn't)
+
+### Good fits
+
+- **Code generation + review**: Separate writing and reviewing catches more bugs
+- **Research + synthesis**: One agent gathers information, another synthesizes it
+- **Long, multi-phase tasks**: Where context window limits would degrade single-agent performance
+- **Tasks requiring diverse tools**: Where no single agent prompt can effectively manage all tools
+
+### Poor fits
+
+- **Simple tasks**: A single well-prompted agent is faster and cheaper
+- **Tightly coupled tasks**: If agents constantly need each other's context, the communication overhead negates the benefits
+- **Latency-sensitive tasks**: Each agent handoff adds latency
+- **Small context needs**: If everything fits in one context window, splitting it adds complexity without benefit
+
+### The Complexity Tax
+
+Every additional agent adds:
+- Communication overhead (serializing/deserializing between agents)
+- Potential for misunderstanding (information lost in translation)
+- Debugging difficulty (which agent went wrong?)
+- Cost multiplication (more LLM calls)
+- Coordination logic that itself can fail
+
+The bar for adding agents should be: "Does the task decompose into genuinely independent sub-problems that benefit from separate contexts?"
+
+## Open Challenges
+
+- **Evaluation**: How do you benchmark multi-agent systems? Individual agent performance doesn't capture coordination quality.
+- **Error propagation**: One bad agent output cascades through the pipeline.
+- **Context sharing**: How much context should agents share? Too much defeats the purpose; too little causes misalignment.
+- **Cost control**: Multi-agent runs can be expensive. How do you set budgets and termination conditions?
+
+## Further Reading
+
+- [AutoGen Paper](https://arxiv.org/abs/2308.08155) - Conversation-based multi-agent framework [src-001]
+- [ChatDev Paper](https://arxiv.org/abs/2307.07924) - Role-based software development [src-002]
+- [CrewAI Docs](https://docs.crewai.com/) - Role-playing agent framework [src-003]
+- [More Agents Is All You Need](https://arxiv.org/abs/2402.05120) - Scaling via ensemble [src-005]
+- [LLM Agent Architectures](agent-architectures.md) - Single-agent patterns
+- [Tool Use and Function Calling](tool-use-function-calling.md) - How agents interact with tools

--- a/topics/agents/tool-use-function-calling.md
+++ b/topics/agents/tool-use-function-calling.md
@@ -1,0 +1,221 @@
+---
+id: kb-2025-008
+title: "Tool Use and Function Calling"
+created: 2025-02-10
+updated: 2025-02-10
+
+author: human
+curation_type: ai_assisted
+
+sources:
+  - id: src-001
+    type: primary
+    title: "Toolformer: Language Models Can Teach Themselves to Use Tools"
+    authors: ["Schick et al."]
+    url: "https://arxiv.org/abs/2302.04761"
+    accessed: 2025-02-10
+    published: 2023-02-09
+    quotes:
+      - text: "We introduce Toolformer, a model trained to decide which APIs to call, when to call them, what arguments to pass, and how to best incorporate the results into future token prediction."
+        location: "Abstract"
+      - text: "Each API call is represented as a tuple (a_c, i_c) where a_c is the name of the API and i_c is the corresponding input."
+        location: "Section 2 - Approach"
+
+  - id: src-002
+    type: primary
+    title: "Gorilla: Large Language Model Connected with Massive APIs"
+    authors: ["Patil et al."]
+    url: "https://arxiv.org/abs/2305.15334"
+    accessed: 2025-02-10
+    published: 2023-05-24
+    quotes:
+      - text: "Gorilla enables LLMs to use tools by invoking APIs. Given a natural language query, Gorilla can write semantically- and syntactically-correct API calls."
+        location: "Abstract"
+
+  - id: src-003
+    type: primary
+    title: "Anthropic Tool Use Documentation"
+    url: "https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview"
+    accessed: 2025-02-10
+    quotes:
+      - text: "Tools are defined by providing Claude with the tool name, a description of what it does, and a JSON Schema for the tool's parameters."
+        location: "How tool use works"
+
+  - id: src-004
+    type: primary
+    title: "OpenAI Function Calling Documentation"
+    url: "https://platform.openai.com/docs/guides/function-calling"
+    accessed: 2025-02-10
+
+  - id: src-005
+    type: primary
+    title: "Berkeley Function-Calling Leaderboard"
+    authors: ["Yan et al."]
+    url: "https://gorilla.cs.berkeley.edu/leaderboard.html"
+    accessed: 2025-02-10
+
+topics:
+  - agents
+  - tool-use
+  - function-calling
+  - ai-fundamentals
+
+confidence: high
+verified: false
+verified_by: unverified
+verification_notes: "AI-assisted draft; quotes sourced from papers and docs but need human verification"
+
+ai_metadata:
+  model: claude-opus-4-6
+  generation_date: 2025-02-10
+  reviewed_by: pending
+---
+
+# Tool Use and Function Calling
+
+## Overview
+
+Tool use is the mechanism by which LLMs interact with the external world — searching the web, reading files, executing code, calling APIs. It transforms a language model from a text generator into an agent that can take real actions.
+
+The core idea is simple: instead of only generating text, the model can also generate structured requests to external tools, receive results, and incorporate those results into its reasoning.
+
+## How Tool Use Works
+
+### The Basic Protocol
+
+Most tool use implementations follow the same pattern:
+
+1. **Define tools**: Tell the model what tools are available, with names, descriptions, and parameter schemas
+2. **Model decides**: Given a user request and available tools, the model either responds directly or generates a tool call
+3. **Execute**: The system (not the model) executes the tool call
+4. **Return results**: Tool output is sent back to the model as a new message
+5. **Continue**: The model reasons about the results and either makes another tool call or produces a final response
+
+This is a **cooperative protocol** — the model proposes actions, the system executes them. The model never directly runs code or accesses external systems.
+
+### Tool Definitions
+
+Tools are specified as structured schemas. In the Anthropic API, "tools are defined by providing Claude with the tool name, a description of what it does, and a JSON Schema for the tool's parameters" [src-003]. For example:
+
+```json
+{
+  "name": "search",
+  "description": "Search the web for current information",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "The search query"
+      }
+    },
+    "required": ["query"]
+  }
+}
+```
+
+The quality of tool descriptions matters enormously — the model uses them to decide when and how to call each tool. Vague descriptions lead to misuse; overly restrictive descriptions lead to underuse.
+
+### Function Calling vs. Tool Use
+
+These terms are used almost interchangeably. "Function calling" (OpenAI's original terminology) and "tool use" (Anthropic's terminology) describe the same capability. The model generates a structured JSON object representing a function/tool invocation, and the caller executes it.
+
+Some providers also support "parallel tool use" (multiple tool calls in a single turn) and "forced tool use" (requiring the model to use a specific tool).
+
+## Approaches to Teaching Tool Use
+
+### Fine-Tuning (Toolformer)
+
+Schick et al. "introduce Toolformer, a model trained to decide which APIs to call, when to call them, what arguments to pass, and how to best incorporate the results into future token prediction" [src-001].
+
+Toolformer's approach was self-supervised:
+1. Sample potential API call positions in training text
+2. Execute the calls and check if including the results reduces perplexity
+3. Fine-tune the model on examples where tools helped
+
+"Each API call is represented as a tuple (a_c, i_c) where a_c is the name of the API and i_c is the corresponding input" [src-001]. The model learns to emit special tokens that trigger tool execution inline with text generation.
+
+### In-Context Learning (Prompting)
+
+Most production systems don't fine-tune for tool use. Instead, tool definitions are injected into the system prompt, and the model learns the calling convention from examples and instructions. This is more flexible (tools can change per request) but depends on the model's instruction-following ability.
+
+### Specialized Training (Gorilla)
+
+Gorilla was trained specifically on API documentation to generate correct API calls. "Given a natural language query, Gorilla can write semantically- and syntactionally-correct API calls" [src-002]. This approach fine-tunes on a curated dataset of API docs and usage examples.
+
+## Tool Use Patterns
+
+### Single-Shot Tool Use
+
+The simplest pattern: user asks a question, model makes one tool call, returns the answer. Good for lookup tasks.
+
+```
+User: What's the weather in Portland?
+Model: [calls weather_api(location="Portland, OR")]
+System: {"temp": 45, "conditions": "rainy"}
+Model: It's 45°F and rainy in Portland.
+```
+
+### Chained Tool Use
+
+Multiple sequential tool calls where each informs the next. The model reasons about intermediate results to decide the next action.
+
+```
+User: Find the bug in my test failures.
+Model: [calls read_file("tests/test_auth.py")]
+Model: [calls read_file("src/auth.py")]  # informed by test file contents
+Model: [calls search_code("validate_token")]  # investigating a function
+Model: The bug is on line 42...
+```
+
+### Parallel Tool Use
+
+When the model needs multiple pieces of independent information, it can issue several tool calls simultaneously. This reduces latency significantly for tasks like "check the status of these three services."
+
+### Tool Use with Confirmation
+
+For high-stakes actions (deleting files, sending emails, modifying databases), the system can require human confirmation before executing. The model proposes the action, the human approves or rejects, and execution proceeds accordingly.
+
+## Practical Considerations
+
+### Tool Design Principles
+
+- **Clear names**: `search_web` over `sw` — the model reads these
+- **Descriptive parameters**: Include `description` fields in the schema, not just type constraints
+- **Atomic operations**: Each tool should do one thing well
+- **Informative errors**: Return structured error messages the model can reason about
+- **Minimal side effects**: Prefer read operations; make writes explicit and confirmable
+
+### Common Failure Modes
+
+- **Hallucinated tools**: The model calls a tool that doesn't exist
+- **Wrong parameters**: Correct tool, incorrect arguments (especially types)
+- **Over-use**: Using a tool when the model already knows the answer
+- **Under-use**: Answering from training data when it should verify with a tool
+- **Infinite loops**: Repeatedly calling the same tool with the same arguments
+
+### Evaluation
+
+The [Berkeley Function-Calling Leaderboard](https://gorilla.cs.berkeley.edu/leaderboard.html) [src-005] tracks model accuracy on tool use across categories:
+- **AST accuracy**: Does the generated call parse correctly?
+- **Exec accuracy**: Does it produce the right result when executed?
+- **Relevance detection**: Does the model correctly identify when no tool is needed?
+
+## The MCP Protocol
+
+The **Model Context Protocol** (MCP) is an open standard for connecting LLMs to external tools and data sources. Rather than each application implementing its own tool integration, MCP provides a unified protocol so tools can be written once and used by any MCP-compatible client.
+
+MCP uses a client-server architecture:
+- **MCP servers** expose tools, resources, and prompts
+- **MCP clients** (like Claude Code, IDEs, or custom apps) connect to servers and make tools available to the model
+
+This standardizes the "plumbing" of tool use so developers can focus on building useful tools rather than integration code.
+
+## Further Reading
+
+- [Toolformer Paper](https://arxiv.org/abs/2302.04761) - Self-supervised tool learning [src-001]
+- [Gorilla Paper](https://arxiv.org/abs/2305.15334) - API-focused tool use [src-002]
+- [Anthropic Tool Use Docs](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview) [src-003]
+- [Berkeley Function-Calling Leaderboard](https://gorilla.cs.berkeley.edu/leaderboard.html) [src-005]
+- [LLM Agent Architectures](agent-architectures.md) - How tool use fits into agent patterns
+- [Multi-Agent Systems](multi-agent-systems.md) - Tools shared across agents

--- a/topics/local-inference/hardware-and-optimization.md
+++ b/topics/local-inference/hardware-and-optimization.md
@@ -1,0 +1,255 @@
+---
+id: kb-2025-012
+title: "Hardware Requirements and Optimization for Local LLM Inference"
+created: 2025-02-10
+updated: 2025-02-10
+
+author: human
+curation_type: ai_assisted
+
+sources:
+  - id: src-001
+    type: primary
+    title: "Efficient Memory Management for Large Language Model Serving with PagedAttention"
+    authors: ["Kwon et al."]
+    url: "https://arxiv.org/abs/2309.06180"
+    accessed: 2025-02-10
+    published: 2023-09-12
+    quotes:
+      - text: "In LLM serving, the KV cache memory for each request is huge and grows and shrinks dynamically. When managed inefficiently, this memory can be significantly wasted by fragmentation and redundant duplication."
+        location: "Abstract"
+
+  - id: src-002
+    type: primary
+    title: "FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness"
+    authors: ["Dao et al."]
+    url: "https://arxiv.org/abs/2205.14135"
+    accessed: 2025-02-10
+    published: 2022-05-27
+    quotes:
+      - text: "We argue that a missing principle is making attention algorithms IO-aware — accounting for reads and writes between levels of GPU memory."
+        location: "Abstract"
+
+  - id: src-003
+    type: primary
+    title: "Speculative Decoding with Big Little Decoder"
+    authors: ["Kim et al."]
+    url: "https://arxiv.org/abs/2302.07863"
+    accessed: 2025-02-10
+    published: 2023-02-15
+    quotes:
+      - text: "The key observation is that in many practical settings, there exists a much smaller model that can generate a large proportion of the tokens that the larger model would have generated."
+        location: "Abstract"
+
+  - id: src-004
+    type: primary
+    title: "Fast Inference from Transformers via Speculative Decoding"
+    authors: ["Leviathan et al."]
+    url: "https://arxiv.org/abs/2211.17192"
+    accessed: 2025-02-10
+    published: 2022-11-30
+    quotes:
+      - text: "Speculative decoding works by first using a faster but less powerful draft model to generate a sequence of tokens, and then using the target model to verify them in parallel."
+        location: "Section 1 (paraphrased from introduction)"
+
+  - id: src-005
+    type: secondary
+    title: "Apple Silicon GPU Memory Architecture"
+    url: "https://developer.apple.com/documentation/metal/gpu_devices_and_work_submission/understanding_gpu_family_4"
+    accessed: 2025-02-10
+
+topics:
+  - local-inference
+  - hardware
+  - optimization
+  - ai-fundamentals
+
+confidence: high
+verified: false
+verified_by: unverified
+verification_notes: "AI-assisted draft; memory estimates are approximate and based on general formulas, specific numbers should be verified against current hardware specs"
+
+ai_metadata:
+  model: claude-opus-4-6
+  generation_date: 2025-02-10
+  reviewed_by: pending
+---
+
+# Hardware Requirements and Optimization for Local LLM Inference
+
+## Overview
+
+Running LLMs locally is fundamentally a memory problem. The model weights must fit in memory (GPU VRAM, system RAM, or both), and there must be headroom for the KV cache that grows with context length. Once a model fits in memory, the next constraint is memory bandwidth — how fast you can feed weights to the compute units.
+
+This article covers practical sizing, hardware options, and optimization techniques for local inference.
+
+## The Memory Equation
+
+### Model Weights
+
+The base memory requirement for model weights:
+
+```
+Weight memory = parameters × (bits_per_weight / 8)
+```
+
+For a 70B model:
+- FP16 (16-bit): 70B × 2 bytes = **140 GB**
+- Q8 (8-bit): 70B × 1 byte = **70 GB**
+- Q4 (4-bit): 70B × 0.5 bytes = **35 GB**
+
+### KV Cache
+
+During generation, the model stores key and value tensors for all previous tokens in the sequence. This is the **KV cache**, and it grows with context length.
+
+Per-token KV cache size:
+```
+KV per token = 2 × num_layers × num_kv_heads × head_dim × bytes_per_value
+```
+
+For Llama 3 70B (80 layers, 8 KV heads, 128 head dim, FP16):
+- Per token: 2 × 80 × 8 × 128 × 2 = **327 KB per token**
+- At 4K context: ~1.3 GB
+- At 32K context: ~10.5 GB
+- At 128K context: ~42 GB
+
+"In LLM serving, the KV cache memory for each request is huge and grows and shrinks dynamically" [src-001]. For long-context local use, the KV cache can rival or exceed the weight memory.
+
+### Total Memory
+
+```
+Total ≈ weight_memory + kv_cache + overhead (~500MB-1GB)
+```
+
+## Hardware Options
+
+### NVIDIA GPUs (CUDA)
+
+The default choice for LLM inference. Key specs that matter:
+
+| GPU | VRAM | Bandwidth | Approx. Price (2024-2025) |
+|-----|------|-----------|--------------------------|
+| RTX 4060 | 8 GB | 272 GB/s | ~$300 |
+| RTX 4070 Ti Super | 16 GB | 672 GB/s | ~$800 |
+| RTX 4090 | 24 GB | 1,008 GB/s | ~$1,600-2,000 |
+| RTX 5090 | 32 GB | 1,792 GB/s | ~$2,000 |
+| A100 | 40/80 GB | 2,039 GB/s | ~$10,000+ (used) |
+| H100 | 80 GB | 3,350 GB/s | ~$25,000+ |
+
+**VRAM is the hard constraint** — if the model doesn't fit, it doesn't run (on GPU alone). Bandwidth determines generation speed.
+
+**Multi-GPU**: Two GPUs can be combined via tensor parallelism, but NVLink bandwidth matters. Consumer GPUs communicate over PCIe (64 GB/s), which is significantly slower than NVLink (900 GB/s on H100). Multi-GPU on consumer cards works but doesn't scale linearly.
+
+### Apple Silicon (Unified Memory)
+
+Apple's M-series chips share memory between CPU and GPU, which is uniquely advantageous for LLMs:
+
+- **M1/M2/M3 Pro**: 18-36 GB unified memory
+- **M2/M3/M4 Max**: 32-128 GB unified memory
+- **M2/M3/M4 Ultra**: 64-192 GB unified memory
+
+The advantage: a Mac Studio with 192GB can load a 70B model at Q4 with room to spare, something that would require multiple NVIDIA GPUs. The disadvantage: GPU memory bandwidth on Apple Silicon (~400-800 GB/s on Max/Ultra) is lower than high-end NVIDIA GPUs, so token generation is slower per token.
+
+**Best for**: Large models that don't fit in discrete GPU VRAM, long-context workloads, single-user local use where throughput isn't critical.
+
+### CPU-Only Inference
+
+When no GPU is available (or the model is too large for any GPU):
+
+- Runs entirely in system RAM (64-512+ GB is commodity)
+- Memory bandwidth is the bottleneck: DDR5 maxes around 50-90 GB/s (vs. 1,000+ GB/s for high-end GPUs)
+- Token generation is 5-20x slower than GPU
+- Viable for smaller models (7-13B quantized) or when latency isn't critical
+
+llama.cpp is the primary engine for CPU inference.
+
+### Partial GPU Offloading
+
+When a model almost fits in VRAM, you can offload some layers to GPU and keep the rest in RAM. llama.cpp handles this natively with the `-ngl` (number of GPU layers) flag.
+
+Performance depends on how many layers fit on GPU:
+- 100% of layers on GPU → full GPU speed
+- 75% on GPU → decent speed, some CPU bottleneck
+- 25% on GPU → only marginally faster than CPU-only
+
+The layers that run on CPU become the bottleneck because data must transfer between CPU and GPU memory each forward pass.
+
+## Optimization Techniques
+
+### Memory Bandwidth is King
+
+For autoregressive generation (the common case), LLM inference is **memory-bandwidth bound**, not compute-bound. Each generated token requires reading the entire model weights from memory once. The arithmetic intensity is extremely low.
+
+This means:
+- Faster GPU compute (more CUDA cores) helps less than you'd expect
+- Higher memory bandwidth helps linearly
+- Quantization helps because smaller weights = less memory to read per token
+
+**Tokens per second** (rough estimate for generation):
+```
+tokens/sec ≈ memory_bandwidth / model_size_in_bytes
+```
+
+A Q4 70B model (~35 GB) on an RTX 4090 (1,008 GB/s): ~29 tokens/sec theoretical maximum. Real numbers are lower due to overhead, but this sets the ceiling.
+
+### Prompt Processing vs. Generation
+
+**Prompt processing** (prefill) processes all input tokens in parallel. This is compute-bound and benefits from GPU parallelism. It's much faster per-token than generation.
+
+**Generation** (decoding) produces one token at a time. This is memory-bandwidth-bound. Each token requires a full pass through the model weights.
+
+This asymmetry means a 10,000-token prompt might process in a few seconds, but generating 1,000 tokens of response takes significantly longer.
+
+### Continuous Batching
+
+When serving multiple users, **continuous batching** interleaves requests. While one request is waiting for its next token, the GPU processes tokens for other requests. This dramatically improves throughput (tokens/second across all users) without hurting per-request latency much. This is a core optimization in vLLM and other serving engines.
+
+### Speculative Decoding
+
+Uses a small "draft" model to predict several tokens ahead, then verifies them all in a single pass through the large model. "In many practical settings, there exists a much smaller model that can generate a large proportion of the tokens that the larger model would have generated" [src-003].
+
+The large model processes the draft tokens in parallel (like prompt processing — fast), accepting correct predictions and rejecting wrong ones. When most predictions are correct, you get multiple tokens per large-model forward pass, improving throughput.
+
+**When it helps**: When a cheap draft model predicts well (common tokens, formulaic text). Less helpful for creative or reasoning-heavy generation.
+
+### Flash Attention and IO-Awareness
+
+FlashAttention makes attention computation faster not by reducing FLOPs but by reducing memory traffic. The key principle: "making attention algorithms IO-aware — accounting for reads and writes between levels of GPU memory" [src-002].
+
+This matters most for long contexts where the attention matrix is large. FlashAttention computes attention in tiles, keeping intermediate results in fast SRAM rather than writing to slow HBM. This is now standard in essentially all inference engines.
+
+### KV Cache Quantization
+
+The KV cache can be quantized separately from model weights (typically to 8-bit or 4-bit), reducing its memory footprint. This extends the maximum context length for a given amount of memory, at the cost of slight quality degradation in long-context tasks.
+
+## Practical Sizing Guide
+
+### What can I run?
+
+| Available Memory | Model Size (Q4) | Examples |
+|-----------------|-----------------|----------|
+| 8 GB VRAM | Up to 7B | Llama 3.1 8B, Mistral 7B, Qwen 2.5 7B |
+| 16 GB VRAM | Up to 13B | Llama 3.1 8B (with long context), CodeLlama 13B |
+| 24 GB VRAM | Up to 30B | Qwen 2.5 32B (tight), Codestral 22B |
+| 32 GB VRAM | Up to 40B | Llama 3.1 70B (partial offload) |
+| 48 GB VRAM | Up to 70B | Llama 3.1 70B, Qwen 2.5 72B |
+| 64 GB unified | Up to 70B | Most 70B models at Q4 with moderate context |
+| 128+ GB unified | Up to 120B+ | Large models at higher quant levels |
+
+These are rough guidelines — actual fit depends on quantization level, context length, and engine overhead.
+
+### The "Good Enough" Local Setup
+
+For most local LLM use cases in 2025:
+- **Budget**: RTX 4060 (8GB) + 7B models. Surprisingly capable for coding assistance and chat.
+- **Mid-range**: RTX 4070 Ti Super (16GB) or Mac with 32-36GB. Runs 7-13B models comfortably.
+- **Enthusiast**: RTX 4090/5090 (24-32GB) or Mac with 64-96GB. Runs 30-70B models.
+- **No-compromise local**: Mac Studio Ultra (192GB) or multi-GPU. Runs the largest open models.
+
+## Further Reading
+
+- [PagedAttention / vLLM Paper](https://arxiv.org/abs/2309.06180) [src-001]
+- [FlashAttention Paper](https://arxiv.org/abs/2205.14135) [src-002]
+- [Speculative Decoding Paper](https://arxiv.org/abs/2302.07863) [src-003]
+- [Quantization Methods](quantization-methods.md) - How to compress models to fit
+- [Inference Engines](inference-engines.md) - Software for running models

--- a/topics/local-inference/inference-engines.md
+++ b/topics/local-inference/inference-engines.md
@@ -1,0 +1,213 @@
+---
+id: kb-2025-011
+title: "Local Inference Engines"
+created: 2025-02-10
+updated: 2025-02-10
+
+author: human
+curation_type: ai_assisted
+
+sources:
+  - id: src-001
+    type: primary
+    title: "llama.cpp GitHub Repository"
+    authors: ["Georgi Gerganov et al."]
+    url: "https://github.com/ggerganov/llama.cpp"
+    accessed: 2025-02-10
+    quotes:
+      - text: "The main goal of llama.cpp is to enable LLM inference with minimal setup and state-of-the-art performance on a wide variety of hardware - locally and in the cloud."
+        location: "README"
+
+  - id: src-002
+    type: primary
+    title: "Efficient Memory Management for Large Language Model Serving with PagedAttention"
+    authors: ["Kwon et al."]
+    url: "https://arxiv.org/abs/2309.06180"
+    accessed: 2025-02-10
+    published: 2023-09-12
+    quotes:
+      - text: "We propose PagedAttention, an attention algorithm inspired by the classical virtual memory and paging techniques in operating systems. On top of it, we build vLLM, an LLM serving system."
+        location: "Abstract"
+      - text: "PagedAttention allows storing continuous key and value tensors in non-contiguous memory space. Specifically, PagedAttention partitions the KV cache of each sequence into KV blocks."
+        location: "Section 4.1 - PagedAttention"
+
+  - id: src-003
+    type: primary
+    title: "Ollama Documentation"
+    url: "https://github.com/ollama/ollama"
+    accessed: 2025-02-10
+    quotes:
+      - text: "Get up and running with large language models."
+        location: "README"
+
+  - id: src-004
+    type: primary
+    title: "SGLang: Efficient Execution of Structured Language Model Programs"
+    authors: ["Zheng et al."]
+    url: "https://arxiv.org/abs/2312.07104"
+    accessed: 2025-02-10
+    published: 2023-12-12
+    quotes:
+      - text: "We introduce SGLang, a system for efficient execution of complex language model programs. SGLang consists of a frontend language and a runtime."
+        location: "Abstract"
+
+  - id: src-005
+    type: primary
+    title: "mlx-lm: Language Models on Apple Silicon"
+    url: "https://github.com/ml-explore/mlx-examples/tree/main/llms/mlx_lm"
+    accessed: 2025-02-10
+
+topics:
+  - local-inference
+  - inference-engines
+  - serving
+  - ai-fundamentals
+
+confidence: high
+verified: false
+verified_by: unverified
+verification_notes: "AI-assisted draft; quotes sourced from repos and papers but need human verification"
+
+ai_metadata:
+  model: claude-opus-4-6
+  generation_date: 2025-02-10
+  reviewed_by: pending
+---
+
+# Local Inference Engines
+
+## Overview
+
+Inference engines are the software that actually runs language models — loading weights, processing tokens, managing memory, and generating output. The choice of engine determines what hardware you can use, how fast generation runs, how many concurrent users you can serve, and what model formats you can load.
+
+The landscape splits roughly into two camps: **local/consumer tools** (optimized for single-user, minimal setup) and **serving engines** (optimized for throughput, concurrency, and production deployment).
+
+## Local-First Engines
+
+### llama.cpp
+
+The project that ignited the local LLM movement. "The main goal of llama.cpp is to enable LLM inference with minimal setup and state-of-the-art performance on a wide variety of hardware - locally and in the cloud" [src-001].
+
+**What it is**: A C/C++ implementation of LLM inference with no dependencies beyond a C compiler. Originally built to run Meta's Llama models on MacBooks, it now supports most open model architectures.
+
+**Key strengths**:
+- **Universal hardware support**: CPU (x86, ARM), NVIDIA GPU (CUDA), Apple GPU (Metal), AMD GPU (ROCm/Vulkan), Intel GPU (SYCL), and more
+- **CPU inference**: Can run entirely on CPU, which no other major engine does well
+- **Partial GPU offloading**: Split a model across GPU and CPU when it doesn't fully fit in VRAM
+- **GGUF format**: The native quantization format, with the widest range of bit widths (2-8 bit)
+- **Minimal dependencies**: Compiles from source with just a C compiler
+- **llama-server**: Built-in OpenAI-compatible API server
+
+**Tradeoffs**:
+- Single-user focused (limited concurrent request handling compared to serving engines)
+- C/C++ codebase can be hard to extend
+- Not the fastest option for pure GPU inference
+
+**When to use**: Consumer hardware, mixed CPU/GPU setups, running quantized models locally, when you need maximum hardware compatibility.
+
+### Ollama
+
+A user-friendly wrapper around llama.cpp (and other backends) that handles model management, downloading, and serving. "Get up and running with large language models" [src-003].
+
+**What it is**: Ollama provides a Docker-like experience for LLMs: `ollama pull llama3` downloads a model, `ollama run llama3` starts a conversation, and `ollama serve` exposes an API.
+
+**Key strengths**:
+- **Simplest setup**: One command to install, one command to run
+- **Model library**: Curated registry of pre-quantized models
+- **Modelfile**: Dockerfile-like format for customizing models (system prompts, parameters, adapters)
+- **Background service**: Runs as a daemon, handles model loading/unloading
+- **OpenAI-compatible API**: Drop-in replacement for many applications
+
+**Tradeoffs**:
+- Less control than using llama.cpp directly
+- Abstracts away quantization choices (uses its own quant selection)
+- Model library is curated but not exhaustive
+- Performance overhead vs. raw llama.cpp is minimal but exists
+
+**When to use**: Getting started with local LLMs, application development against a local API, when you want simplicity over fine-tuning control.
+
+### MLX / mlx-lm
+
+Apple's ML framework optimized for Apple Silicon. mlx-lm [src-005] is the language model inference library built on it.
+
+**Key strengths**:
+- **Apple Silicon native**: Uses the unified memory architecture directly (GPU and CPU share memory pool)
+- **No memory copy**: Models load directly into unified memory, no CPU→GPU transfer needed
+- **Python-first**: Easy to extend and customize
+- **Quantization support**: 4-bit and 8-bit, with good quality
+
+**Tradeoffs**:
+- Apple Silicon only (M1/M2/M3/M4)
+- Smaller ecosystem than llama.cpp
+- Fewer model architectures supported
+
+**When to use**: Mac users who want native performance without GGUF conversion.
+
+## Serving Engines
+
+### vLLM
+
+The most widely deployed open-source LLM serving engine. Built around **PagedAttention**: "an attention algorithm inspired by the classical virtual memory and paging techniques in operating systems" [src-002].
+
+**The PagedAttention insight**: During inference, the KV cache (stored attention states for generated tokens) wastes enormous amounts of GPU memory due to fragmentation. Traditional systems pre-allocate contiguous memory blocks for the maximum sequence length, wasting memory on shorter sequences. PagedAttention "allows storing continuous key and value tensors in non-contiguous memory space" by partitioning "the KV cache of each sequence into KV blocks" [src-002] — just like virtual memory pages.
+
+**Key strengths**:
+- **Throughput**: Optimized for serving many concurrent requests
+- **PagedAttention**: ~2-4x better memory utilization than naive implementations
+- **Continuous batching**: New requests are added to the batch without waiting for existing ones to finish
+- **Broad model support**: Hugging Face Transformers format, GPTQ, AWQ, and more
+- **OpenAI-compatible API**: Drop-in replacement for production deployments
+- **Tensor parallelism**: Split models across multiple GPUs
+
+**Tradeoffs**:
+- GPU-only (NVIDIA primarily, some AMD support)
+- Higher minimum hardware requirements than local engines
+- More complex setup than Ollama
+- Optimized for throughput over single-request latency
+
+**When to use**: Production serving, multi-user scenarios, when you need maximum throughput on GPU hardware.
+
+### SGLang
+
+"A system for efficient execution of complex language model programs" [src-004]. SGLang focuses on structured generation and complex LLM programs (multi-turn, branching, constrained output).
+
+**Key strengths**:
+- **RadixAttention**: Automatic KV cache reuse across requests with shared prefixes
+- **Structured generation**: Efficient constrained decoding (JSON, regex, grammar)
+- **Frontend language**: Python DSL for complex generation programs
+- **Competitive throughput**: Often matches or exceeds vLLM on benchmarks
+
+**Tradeoffs**:
+- Newer ecosystem, fewer production deployments
+- GPU-focused (NVIDIA)
+- The frontend DSL is powerful but adds learning curve
+
+**When to use**: Structured output generation, complex multi-step LLM programs, workloads with shared prefixes (e.g., same system prompt across requests).
+
+### Text Generation Inference (TGI)
+
+Hugging Face's serving solution. Rust-based, production-tested at scale on HF's own infrastructure. Good default choice for teams already in the Hugging Face ecosystem.
+
+## Comparison
+
+| Engine | Primary Use | Hardware | Model Format | Ease of Setup |
+|--------|------------|----------|--------------|--------------|
+| llama.cpp | Local, consumer | CPU + any GPU | GGUF | Medium |
+| Ollama | Local, developer | CPU + any GPU | Ollama library | Easy |
+| MLX | Local, Mac | Apple Silicon | MLX/safetensors | Easy |
+| vLLM | Serving | GPU (NVIDIA/AMD) | HF/GPTQ/AWQ | Medium |
+| SGLang | Serving, structured | GPU (NVIDIA) | HF/GPTQ/AWQ | Medium |
+| TGI | Serving | GPU (NVIDIA) | HF/GPTQ/AWQ | Medium |
+
+## The OpenAI-Compatible API Convention
+
+Nearly every inference engine now exposes an API matching OpenAI's chat completions format (`/v1/chat/completions`). This has become the de facto standard for LLM APIs, making it possible to swap backends without changing application code. This is one of the most important practical developments in the local LLM ecosystem — it decouples application development from model serving.
+
+## Further Reading
+
+- [llama.cpp GitHub](https://github.com/ggerganov/llama.cpp) [src-001]
+- [vLLM Paper](https://arxiv.org/abs/2309.06180) [src-002]
+- [Ollama GitHub](https://github.com/ollama/ollama) [src-003]
+- [SGLang Paper](https://arxiv.org/abs/2312.07104) [src-004]
+- [Quantization Methods](quantization-methods.md) - How models are compressed for these engines
+- [Hardware and Optimization](hardware-and-optimization.md) - Choosing hardware for inference

--- a/topics/local-inference/quantization-methods.md
+++ b/topics/local-inference/quantization-methods.md
@@ -1,0 +1,223 @@
+---
+id: kb-2025-010
+title: "Quantization Methods for Large Language Models"
+created: 2025-02-10
+updated: 2025-02-10
+
+author: human
+curation_type: ai_assisted
+
+sources:
+  - id: src-001
+    type: primary
+    title: "GPTQ: Accurate Post-Training Quantization for Generative Pre-trained Transformers"
+    authors: ["Frantar et al."]
+    url: "https://arxiv.org/abs/2210.17323"
+    accessed: 2025-02-10
+    published: 2022-10-31
+    quotes:
+      - text: "GPTQ, a new one-shot weight quantization method based on approximate second-order information, that is both highly-accurate and highly-efficient."
+        location: "Abstract"
+      - text: "GPTQ can quantize GPT models with 175 billion parameters in approximately four GPU hours, reducing the bitwidth down to 3 or 4 bits per weight, with negligible accuracy degradation relative to the unquantized baseline."
+        location: "Abstract"
+
+  - id: src-002
+    type: primary
+    title: "AWQ: Activation-aware Weight Quantization for LLM Compression and Acceleration"
+    authors: ["Lin et al."]
+    url: "https://arxiv.org/abs/2306.00978"
+    accessed: 2025-02-10
+    published: 2023-06-01
+    quotes:
+      - text: "We propose Activation-aware Weight Quantization (AWQ), a hardware-friendly approach for LLM low-bit weight-only quantization. Our method is based on the observation that weights are not equally important: protecting only 1% of salient weights can greatly reduce quantization error."
+        location: "Abstract"
+      - text: "AWQ does not rely on any backpropagation or reconstruction, so it can well preserve LLMs' generalization ability on different domains and modalities, without overfitting to the calibration set."
+        location: "Abstract"
+
+  - id: src-003
+    type: primary
+    title: "LLM.int8(): 8-bit Matrix Multiplication for Transformers at Scale"
+    authors: ["Dettmers et al."]
+    url: "https://arxiv.org/abs/2208.07339"
+    accessed: 2025-02-10
+    published: 2022-08-15
+    quotes:
+      - text: "We develop a procedure for Int8 matrix multiplication for feed-forward and attention projection layers in transformers, which cut the memory needed for inference by half while retaining full precision performance."
+        location: "Abstract"
+      - text: "We show for the first time that a multi-billion-parameter transformer can be run at the full 16-bit performance level using only 8-bit weights."
+        location: "Abstract"
+
+  - id: src-004
+    type: primary
+    title: "GGUF Format Specification"
+    url: "https://github.com/ggerganov/ggml/blob/master/docs/gguf.md"
+    accessed: 2025-02-10
+    quotes:
+      - text: "GGUF is a file format for storing models for inference with GGML and executors based on GGML."
+        location: "Introduction"
+
+  - id: src-005
+    type: primary
+    title: "QuIP#: Even Better LLM Quantization with Hadamard Incoherence and Lattice Codebooks"
+    authors: ["Tseng et al."]
+    url: "https://arxiv.org/abs/2402.04396"
+    accessed: 2025-02-10
+    published: 2024-02-06
+
+topics:
+  - quantization
+  - local-inference
+  - optimization
+  - ai-fundamentals
+
+confidence: high
+verified: false
+verified_by: unverified
+verification_notes: "AI-assisted draft; quotes sourced from papers but need human verification against originals"
+
+ai_metadata:
+  model: claude-opus-4-6
+  generation_date: 2025-02-10
+  reviewed_by: pending
+---
+
+# Quantization Methods for Large Language Models
+
+## Overview
+
+Quantization reduces the numerical precision of model weights (and sometimes activations) to make models smaller and faster. A 70B parameter model in 16-bit precision requires ~140GB of memory — far beyond consumer hardware. Quantize to 4-bit and it fits in ~35GB, within reach of high-end consumer GPUs.
+
+The core tradeoff is straightforward: lower precision means smaller models and faster inference, but potentially degraded output quality. The art is in minimizing that quality loss.
+
+## Why Quantization Works
+
+Neural network weights are stored as floating-point numbers, typically 16-bit (FP16/BF16) or 32-bit (FP32). But most of these bits encode precision the model doesn't need. The distribution of weight values is typically concentrated in a narrow range, with a few outliers. Quantization exploits this by mapping the continuous weight values to a smaller set of discrete values.
+
+The key insight: models are remarkably robust to weight perturbations. Small rounding errors in individual weights largely cancel out across millions of parameters. The challenge is handling the outlier weights that carry disproportionate importance.
+
+## Quantization Approaches
+
+### Weight-Only vs. Weight-and-Activation
+
+**Weight-only quantization** compresses just the model weights. During inference, weights are dequantized back to higher precision for the actual computation. This reduces memory and loading time but doesn't reduce computation cost proportionally.
+
+**Weight-and-activation quantization** also quantizes the intermediate values during computation, enabling integer arithmetic on hardware that supports it. More aggressive but potentially more lossy.
+
+Most practical LLM quantization today is weight-only.
+
+### Post-Training Quantization (PTQ) vs. Quantization-Aware Training (QAT)
+
+**PTQ** quantizes a model after training is complete, typically using a small calibration dataset. This is what most methods below use — it's fast (hours, not weeks) and doesn't require retraining.
+
+**QAT** incorporates quantization into the training process, letting the model learn to compensate for precision loss. Produces better results but requires the full training pipeline. More common for smaller models and deployment-critical applications.
+
+## Major Methods
+
+### GPTQ
+
+"A new one-shot weight quantization method based on approximate second-order information, that is both highly-accurate and highly-efficient" [src-001]. GPTQ was a breakthrough because it showed that "GPT models with 175 billion parameters [can be quantized] in approximately four GPU hours, reducing the bitwidth down to 3 or 4 bits per weight, with negligible accuracy degradation" [src-001].
+
+**How it works**: GPTQ quantizes weights layer by layer, using second-order (Hessian) information to determine which weights are most sensitive to quantization error and adjusting remaining weights to compensate. It processes weights in groups and uses a calibration dataset (typically ~128 samples) to measure activation patterns.
+
+**Characteristics**:
+- GPU-accelerated quantization and inference
+- 4-bit and 3-bit support
+- Requires GPU for efficient inference (uses CUDA kernels)
+- Widely supported (Hugging Face Transformers, vLLM, text-generation-inference)
+
+### AWQ (Activation-Aware Weight Quantization)
+
+"Based on the observation that weights are not equally important: protecting only 1% of salient weights can greatly reduce quantization error" [src-002].
+
+**How it works**: Instead of treating all weights equally, AWQ identifies the most important weights by looking at activation magnitudes (not weight magnitudes). Weights connected to channels with large activations are scaled up before quantization, preserving their precision. Critically, "AWQ does not rely on any backpropagation or reconstruction, so it can well preserve LLMs' generalization ability on different domains and modalities, without overfitting to the calibration set" [src-002].
+
+**Characteristics**:
+- Often slightly better quality than GPTQ at the same bit width
+- Hardware-friendly (no special kernel requirements)
+- Good generalization — doesn't overfit to calibration data
+- 4-bit focus
+- Supported by vLLM, text-generation-inference, and many frameworks
+
+### GGUF / llama.cpp Quantization
+
+"GGUF is a file format for storing models for inference with GGML and executors based on GGML" [src-004]. The GGUF format includes a family of quantization types specific to the llama.cpp ecosystem.
+
+**Quantization types** (common ones):
+- **Q8_0**: 8-bit, ~8.5 bpw (bits per weight). Virtually lossless.
+- **Q6_K**: 6-bit with k-quant optimization. Near-lossless for most models.
+- **Q5_K_M**: 5-bit, medium quality. Good balance point.
+- **Q4_K_M**: 4-bit, medium quality. Most popular for consumer hardware.
+- **Q3_K_M**: 3-bit, medium quality. Noticeable quality loss on smaller models.
+- **Q2_K**: 2-bit. Significant quality loss; mainly useful for very large models.
+- **IQ4_XS, IQ3_S, etc.**: "Importance matrix" variants that use calibration data for better quality at extreme compression.
+
+The "K" variants (k-quants) use different bit widths for different layers, allocating more bits to sensitive layers. The "IQ" variants use importance-based quantization.
+
+**Characteristics**:
+- CPU-first design (runs on any hardware)
+- Also supports GPU offloading (CUDA, Metal, Vulkan)
+- Self-contained single-file format
+- Wide range of quantization levels (2-8 bit)
+- The most common format for local inference
+
+### bitsandbytes (LLM.int8 / QLoRA)
+
+Dettmers et al. showed that "a multi-billion-parameter transformer can be run at the full 16-bit performance level using only 8-bit weights" [src-003]. The key was handling outlier features separately — the few dimensions with large magnitudes are kept in 16-bit while everything else is quantized to 8-bit.
+
+**Characteristics**:
+- Integrated with Hugging Face Transformers (one-line quantization)
+- 8-bit (LLM.int8()) and 4-bit (NF4 for QLoRA) support
+- Primary use case: fitting models into GPU memory for fine-tuning (QLoRA)
+- Runtime quantization (no separate quantization step)
+- NVIDIA GPU required
+
+### QuIP# and Extreme Quantization
+
+Research methods pushing to 2-bit and below. QuIP# uses Hadamard transforms to spread information across weights before quantization, making each weight carry more uniform importance [src-005]. These methods are more experimental but point toward the future.
+
+## Comparison
+
+| Method | Typical Bits | Speed | Hardware | Best For |
+|--------|-------------|-------|----------|----------|
+| GPTQ | 3-4 | Fast inference | GPU (CUDA) | GPU serving |
+| AWQ | 4 | Fast inference | GPU (CUDA) | GPU serving, generalization |
+| GGUF | 2-8 | Varies | CPU + optional GPU | Local/consumer, flexibility |
+| bitsandbytes | 4-8 | Moderate | GPU (CUDA) | Fine-tuning (QLoRA) |
+
+## Practical Guidelines
+
+### Choosing a Bit Width
+
+- **8-bit**: Virtually no quality loss. Use when memory is tight but not critical.
+- **6-bit**: Negligible quality loss for most models. Good default if you have the memory.
+- **5-bit**: Slight quality loss, often hard to notice. Good balance.
+- **4-bit**: The sweet spot for consumer hardware. Noticeable quality loss on smaller models (<13B), acceptable on larger ones.
+- **3-bit**: Measurable quality degradation. Acceptable for very large models (70B+) where it's the only way to fit.
+- **2-bit**: Significant degradation. Last resort for extreme constraints.
+
+### Rule of Thumb for Memory
+
+Memory required ≈ (parameters × bits_per_weight) / 8 + overhead
+
+- 7B model at Q4: ~4-5 GB
+- 13B model at Q4: ~8-9 GB
+- 34B model at Q4: ~20 GB
+- 70B model at Q4: ~35-40 GB
+
+Add ~1-2 GB for context (KV cache) depending on sequence length.
+
+### Choosing a Method
+
+- **Running locally on CPU or mixed CPU/GPU?** → GGUF
+- **Serving on a GPU?** → AWQ or GPTQ
+- **Fine-tuning on limited GPU memory?** → bitsandbytes (QLoRA)
+- **Need maximum quality at given bit width?** → AWQ or IQ-quants (GGUF)
+
+## Further Reading
+
+- [GPTQ Paper](https://arxiv.org/abs/2210.17323) [src-001]
+- [AWQ Paper](https://arxiv.org/abs/2306.00978) [src-002]
+- [LLM.int8() Paper](https://arxiv.org/abs/2208.07339) [src-003]
+- [GGUF Spec](https://github.com/ggerganov/ggml/blob/master/docs/gguf.md) [src-004]
+- [Inference Engines](inference-engines.md) - Software that runs quantized models
+- [Hardware and Optimization](hardware-and-optimization.md) - Sizing your setup

--- a/topics/transformers/attention-mechanism.md
+++ b/topics/transformers/attention-mechanism.md
@@ -1,0 +1,126 @@
+---
+id: kb-2025-004
+title: "The Attention Mechanism"
+created: 2025-02-10
+updated: 2025-02-10
+
+author: human
+curation_type: ai_assisted
+
+sources:
+  - id: src-001
+    type: primary
+    title: "Attention Is All You Need"
+    authors: ["Vaswani et al."]
+    url: "https://arxiv.org/abs/1706.03762"
+    accessed: 2025-02-10
+    published: 2017-06-12
+    quotes:
+      - text: "An attention function can be described as mapping a query and a set of key-value pairs to an output, where the query, keys, values, and output are all vectors."
+        location: "Section 3.2 - Attention"
+      - text: "We call our particular attention 'Scaled Dot-Product Attention'. The input consists of queries and keys of dimension d_k, and values of dimension d_v."
+        location: "Section 3.2.1 - Scaled Dot-Product Attention"
+      - text: "Multi-head attention allows the model to jointly attend to information from different representation subspaces at different positions."
+        location: "Section 3.2.2 - Multi-Head Attention"
+
+  - id: src-002
+    type: primary
+    title: "Neural Machine Translation by Jointly Learning to Align and Translate"
+    authors: ["Bahdanau, Cho, Bengio"]
+    url: "https://arxiv.org/abs/1409.0473"
+    accessed: 2025-02-10
+    published: 2014-09-01
+    quotes:
+      - text: "We conjecture that the use of a fixed-length vector is a bottleneck in improving the performance of this basic encoder-decoder architecture"
+        location: "Abstract"
+      - text: "Each time the proposed model generates a word in a translation, it (soft-)searches for a set of positions in a source sentence where the most relevant information is concentrated."
+        location: "Abstract"
+
+  - id: src-003
+    type: secondary
+    title: "The Illustrated Transformer"
+    authors: ["Jay Alammar"]
+    url: "https://jalammar.github.io/illustrated-transformer/"
+    accessed: 2025-02-10
+    published: 2018-06-27
+
+topics:
+  - transformers
+  - attention
+  - architecture
+  - ai-fundamentals
+
+confidence: high
+verified: false
+verified_by: unverified
+verification_notes: "AI-assisted draft; quotes sourced from papers but need human verification against originals"
+
+ai_metadata:
+  model: claude-opus-4-6
+  generation_date: 2025-02-10
+  reviewed_by: pending
+---
+
+# The Attention Mechanism
+
+## Overview
+
+Attention is the core innovation behind modern transformer models. At its heart, it's a mechanism that lets a model dynamically decide which parts of its input are relevant to each part of its output, rather than compressing everything into a fixed-size representation.
+
+## The Problem Attention Solves
+
+Before attention, sequence-to-sequence models (used for translation, summarization, etc.) relied on encoding an entire input sequence into a single fixed-length vector. Bahdanau et al. identified this as a fundamental bottleneck: "the use of a fixed-length vector is a bottleneck in improving the performance of this basic encoder-decoder architecture" [src-002].
+
+Their solution was to let the decoder look back at all encoder hidden states and learn which ones matter for each output step. The model "(soft-)searches for a set of positions in a source sentence where the most relevant information is concentrated" [src-002]. This was the birth of the attention mechanism for neural networks.
+
+## Scaled Dot-Product Attention
+
+Vaswani et al. formalized attention as a general operation: "an attention function can be described as mapping a query and a set of key-value pairs to an output, where the query, keys, values, and output are all vectors" [src-001].
+
+The specific formulation used in transformers is **Scaled Dot-Product Attention** [src-001]:
+
+```
+Attention(Q, K, V) = softmax(Q·K^T / √d_k) · V
+```
+
+The steps:
+1. **Dot product**: Compute similarity between each query and all keys (`Q·K^T`)
+2. **Scale**: Divide by `√d_k` to prevent the dot products from growing too large in magnitude, which would push softmax into regions with vanishingly small gradients
+3. **Softmax**: Convert to a probability distribution (attention weights)
+4. **Weighted sum**: Multiply weights by values to get the output
+
+The query, key, value framing comes from information retrieval: you have a *query* (what you're looking for), *keys* (labels for available information), and *values* (the actual information). The attention weights determine how much of each value to retrieve.
+
+## Multi-Head Attention
+
+Rather than computing attention once, transformers use **multi-head attention**: running multiple attention operations in parallel, each with different learned projections. "Multi-head attention allows the model to jointly attend to information from different representation subspaces at different positions" [src-001].
+
+```
+MultiHead(Q, K, V) = Concat(head_1, ..., head_h) · W^O
+where head_i = Attention(Q·W_i^Q, K·W_i^K, V·W_i^V)
+```
+
+Each "head" learns to attend to different types of relationships. In practice, different heads specialize in different patterns - some track syntactic relationships, others semantic ones, others positional patterns.
+
+## Self-Attention vs. Cross-Attention
+
+**Self-attention**: Queries, keys, and values all come from the same sequence. Each token attends to every other token in the same sequence. This is how a model builds contextual representations - the meaning of a word depends on the words around it.
+
+**Cross-attention**: Queries come from one sequence, keys and values from another. This is used in encoder-decoder models where the decoder needs to attend to the encoder's output (similar to Bahdanau's original formulation).
+
+In decoder-only models (like GPT), only self-attention is used, with a causal mask preventing tokens from attending to future positions.
+
+## Computational Cost
+
+The fundamental cost of self-attention is **O(n^2)** in sequence length, because every token must compute attention scores against every other token. For a sequence of length `n`:
+- The attention matrix is `n × n`
+- Both compute and memory scale quadratically
+
+This quadratic scaling is the primary constraint on context length and has driven significant research into efficient attention variants (see [Modern Transformer Variants](modern-variants.md)).
+
+## Further Reading
+
+- [Attention Is All You Need](https://arxiv.org/abs/1706.03762) - The transformer paper
+- [Bahdanau et al., 2014](https://arxiv.org/abs/1409.0473) - Original attention for seq2seq
+- [The Illustrated Transformer](https://jalammar.github.io/illustrated-transformer/) - Visual walkthrough [src-003]
+- [Transformer Architecture Overview](transformer-architecture.md) - How attention fits into the full model

--- a/topics/transformers/modern-variants.md
+++ b/topics/transformers/modern-variants.md
@@ -1,0 +1,222 @@
+---
+id: kb-2025-006
+title: "Modern Transformer Variants"
+created: 2025-02-10
+updated: 2025-02-10
+
+author: human
+curation_type: ai_assisted
+
+sources:
+  - id: src-001
+    type: primary
+    title: "Language Models are Unsupervised Multitask Learners"
+    authors: ["Radford et al."]
+    url: "https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf"
+    accessed: 2025-02-10
+    published: 2019-02-14
+    quotes:
+      - text: "Language models can be trained without any explicit supervision"
+        location: "Abstract (paraphrased from title/introduction)"
+      - text: "We demonstrate that language models begin to learn these tasks without any explicit supervision when trained on a new dataset of millions of webpages called WebText."
+        location: "Abstract"
+
+  - id: src-002
+    type: primary
+    title: "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding"
+    authors: ["Devlin et al."]
+    url: "https://arxiv.org/abs/1810.04805"
+    accessed: 2025-02-10
+    published: 2018-10-11
+    quotes:
+      - text: "Unlike recent language representation models, BERT is designed to pre-train deep bidirectional representations from unlabeled text by jointly conditioning on both left and right context in all layers."
+        location: "Abstract"
+      - text: "We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations from Transformers."
+        location: "Abstract"
+
+  - id: src-003
+    type: primary
+    title: "Exploring the Limits of Transfer Learning with a Unified Text-to-Text Transformer"
+    authors: ["Raffel et al."]
+    url: "https://arxiv.org/abs/1910.10683"
+    accessed: 2025-02-10
+    published: 2019-10-23
+    quotes:
+      - text: "We introduce a unified framework that converts all text-based language problems into a text-to-text format."
+        location: "Abstract"
+
+  - id: src-004
+    type: primary
+    title: "Outrageously Large Neural Networks: The Sparsely-Gated Mixture-of-Experts Layer"
+    authors: ["Shazeer et al."]
+    url: "https://arxiv.org/abs/1701.06538"
+    accessed: 2025-02-10
+    published: 2017-01-23
+    quotes:
+      - text: "The MoE consists of a number of experts, each a simple feed-forward neural network, and a trainable gating network which selects a sparse combination of the experts to process each input."
+        location: "Section 2 - The Structure of the Mixture-of-Experts Layer"
+
+  - id: src-005
+    type: primary
+    title: "FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness"
+    authors: ["Dao et al."]
+    url: "https://arxiv.org/abs/2205.14135"
+    accessed: 2025-02-10
+    published: 2022-05-27
+    quotes:
+      - text: "We propose FlashAttention, an IO-aware exact attention algorithm that uses tiling to reduce the number of memory reads/writes between GPU high bandwidth memory (HBM) and GPU on-chip SRAM."
+        location: "Abstract"
+
+  - id: src-006
+    type: primary
+    title: "RoFormer: Enhanced Transformer with Rotary Position Embedding"
+    authors: ["Su et al."]
+    url: "https://arxiv.org/abs/2104.09864"
+    accessed: 2025-02-10
+    published: 2021-04-20
+    quotes:
+      - text: "We propose a novel method named Rotary Position Embedding (RoPE) to encode position information with a rotation matrix."
+        location: "Abstract"
+
+  - id: src-007
+    type: primary
+    title: "GLU Variants Improve Transformer"
+    authors: ["Shazeer"]
+    url: "https://arxiv.org/abs/2002.05202"
+    accessed: 2025-02-10
+    published: 2020-02-12
+
+topics:
+  - transformers
+  - architecture
+  - model-variants
+  - ai-fundamentals
+
+confidence: high
+verified: false
+verified_by: unverified
+verification_notes: "AI-assisted draft; quotes sourced from papers but need human verification against originals"
+
+ai_metadata:
+  model: claude-opus-4-6
+  generation_date: 2025-02-10
+  reviewed_by: pending
+---
+
+# Modern Transformer Variants
+
+## Overview
+
+The original 2017 Transformer was an encoder-decoder model for machine translation. Since then, the architecture has diverged into several major families, each optimized for different use cases. This article surveys the key variants and the innovations that have pushed transformers to their current scale.
+
+## Architectural Families
+
+### Decoder-Only (GPT Family)
+
+The GPT approach uses only the transformer decoder with causal (left-to-right) self-attention masking. Each token can only attend to tokens before it, making the model naturally autoregressive - it generates text one token at a time.
+
+Radford et al. showed that "language models begin to learn these tasks without any explicit supervision when trained on a new dataset of millions of webpages" [src-001]. The key insight was that a large enough language model, trained on enough data, develops general capabilities as a byproduct of next-token prediction.
+
+**Examples**: GPT-2, GPT-3, GPT-4, Llama, Mistral, Claude's underlying architecture, Gemini
+
+**Strengths**: Natural text generation, scales well, simple training objective (predict next token)
+**Tradeoffs**: Unidirectional context (can't look ahead), generation is inherently sequential at inference time
+
+Decoder-only models dominate the current LLM landscape. Nearly all frontier models use this architecture.
+
+### Encoder-Only (BERT Family)
+
+BERT uses only the transformer encoder with bidirectional attention - each token can attend to all other tokens. "BERT is designed to pre-train deep bidirectional representations from unlabeled text by jointly conditioning on both left and right context in all layers" [src-002].
+
+BERT is trained with **masked language modeling** (MLM): randomly mask 15% of input tokens and predict them. This forces the model to develop deep bidirectional representations, since any token might need to be predicted.
+
+**Examples**: BERT, RoBERTa, DeBERTa, ELECTRA
+
+**Strengths**: Rich bidirectional representations, excellent for classification and understanding tasks
+**Tradeoffs**: Not naturally generative (can't produce open-ended text), largely superseded by decoder-only models for most tasks
+
+### Encoder-Decoder (T5 Family)
+
+T5 preserves the original transformer structure but frames all tasks as text-to-text: "a unified framework that converts all text-based language problems into a text-to-text format" [src-003]. Translation, summarization, question answering, and classification all become "input text in, output text out."
+
+**Examples**: T5, FLAN-T5, BART, mBART, UL2
+
+**Strengths**: Natural fit for tasks with distinct input/output (translation, summarization), can leverage encoder's bidirectional context
+**Tradeoffs**: More complex than decoder-only, less common in frontier models
+
+## Key Innovations Since 2017
+
+### Mixture of Experts (MoE)
+
+MoE replaces the dense feed-forward layers with multiple parallel "expert" networks and a learned routing mechanism. "The MoE consists of a number of experts, each a simple feed-forward neural network, and a trainable gating network which selects a sparse combination of the experts to process each input" [src-004].
+
+Only a subset of experts (typically 1-2 out of 8+) are activated per token, so the model has many more total parameters than it uses for any given input. This allows much larger model capacity without proportionally increasing compute.
+
+**Examples**: Mixtral 8x7B (activates 2 of 8 experts per token), GPT-4 (reported to use MoE), DeepSeek-V3
+
+**Tradeoffs**: Higher memory (all experts must be loaded), routing instability during training, but dramatically better compute efficiency per parameter
+
+### Rotary Position Embeddings (RoPE)
+
+RoPE replaced the original sinusoidal and learned position embeddings. Su et al. "propose a novel method named Rotary Position Embedding (RoPE) to encode position information with a rotation matrix" [src-006].
+
+RoPE encodes positions by rotating the query and key vectors in 2D subspaces. The dot product between rotated vectors naturally decays with distance, giving the model a built-in recency bias. Critically, RoPE can be extrapolated to longer sequences than seen during training, though various extensions (YaRN, dynamic NTK scaling) improve this further.
+
+**Adopted by**: Llama, Mistral, Qwen, PaLM, Gemma, and most modern open models
+
+### SwiGLU / Gated Linear Units
+
+The original transformer FFN used ReLU activation: `FFN(x) = max(0, xW₁ + b₁)W₂ + b₂`. Shazeer showed that gated variants, particularly SwiGLU, consistently outperform ReLU in transformers [src-007]:
+
+```
+SwiGLU(x) = (x·W₁ ⊙ Swish(x·W_gate))·W₂
+```
+
+The gating mechanism (element-wise multiplication with a learned gate) gives the network more expressive power. SwiGLU is now standard in most modern architectures.
+
+### FlashAttention
+
+FlashAttention doesn't change the mathematical operation - it computes exact attention - but radically changes *how* it's computed on GPUs. Dao et al. "propose FlashAttention, an IO-aware exact attention algorithm that uses tiling to reduce the number of memory reads/writes between GPU high bandwidth memory (HBM) and GPU on-chip SRAM" [src-005].
+
+By restructuring the computation to minimize data movement between memory levels (not just minimize FLOPs), FlashAttention achieves 2-4x wall-clock speedup and enables much longer context lengths. FlashAttention-2 and FlashAttention-3 further improved performance.
+
+**Impact**: Enabled the jump from ~4K to 128K+ context lengths in production models.
+
+### Grouped Query Attention (GQA)
+
+The original multi-head attention has separate K and V projections for each head. GQA shares K and V across groups of heads (e.g., 8 query heads per KV head). This dramatically reduces the KV cache size during inference - the primary memory bottleneck for long-context generation - with minimal quality loss.
+
+**Adopted by**: Llama 2 70B, Llama 3, Mistral, and most production models
+
+### RMSNorm
+
+A simplification of LayerNorm that drops the mean-centering step and only normalizes by root mean square. Slightly cheaper to compute, and empirically works just as well. Standard in Llama and most modern architectures.
+
+### Pre-LN vs. Post-LN
+
+The original transformer applies LayerNorm after the residual connection (Post-LN). Most modern models apply it before the sub-layer (Pre-LN), which produces more stable gradients and is easier to train at scale. Some architectures sandwich normalization both before and after.
+
+## The Modern Recipe
+
+A typical 2024-2025 frontier model combines:
+
+| Component | Original (2017) | Modern Standard |
+|-----------|-----------------|-----------------|
+| Architecture | Encoder-decoder | Decoder-only |
+| Position encoding | Sinusoidal | RoPE |
+| Normalization | Post-LN LayerNorm | Pre-LN RMSNorm |
+| FFN activation | ReLU | SwiGLU |
+| Attention | Multi-head | Grouped Query (GQA) |
+| Attention kernel | Naive | FlashAttention |
+| Sparsity | Dense | MoE (for some) |
+| Context length | 512 tokens | 128K-1M+ tokens |
+
+Each of these changes is incremental, but together they represent a fundamentally different beast from the 2017 model.
+
+## Further Reading
+
+- [GPT-2 Paper](https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf) [src-001]
+- [BERT Paper](https://arxiv.org/abs/1810.04805) [src-002]
+- [FlashAttention Paper](https://arxiv.org/abs/2205.14135) [src-005]
+- [The Attention Mechanism](attention-mechanism.md) - Foundation for all variants
+- [Transformer Architecture Overview](transformer-architecture.md) - The original design

--- a/topics/transformers/transformer-architecture.md
+++ b/topics/transformers/transformer-architecture.md
@@ -1,0 +1,163 @@
+---
+id: kb-2025-005
+title: "Transformer Architecture Overview"
+created: 2025-02-10
+updated: 2025-02-10
+
+author: human
+curation_type: ai_assisted
+
+sources:
+  - id: src-001
+    type: primary
+    title: "Attention Is All You Need"
+    authors: ["Vaswani et al."]
+    url: "https://arxiv.org/abs/1706.03762"
+    accessed: 2025-02-10
+    published: 2017-06-12
+    quotes:
+      - text: "We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely."
+        location: "Abstract"
+      - text: "The encoder maps an input sequence of symbol representations to a sequence of continuous representations. Given z, the decoder then generates an output sequence of symbols one element at a time."
+        location: "Section 3.1 - Encoder and Decoder Stacks"
+      - text: "Since our model contains no recurrence and no convolution, in order for the model to make use of the order of the sequence, we must inject some information about the relative or absolute position of the tokens in the sequence."
+        location: "Section 3.5 - Positional Encoding"
+      - text: "We employ a residual connection around each of the two sub-layers, followed by layer normalization."
+        location: "Section 3.1 - Encoder and Decoder Stacks"
+
+  - id: src-002
+    type: primary
+    title: "Layer Normalization"
+    authors: ["Ba, Kiros, Hinton"]
+    url: "https://arxiv.org/abs/1607.06450"
+    accessed: 2025-02-10
+    published: 2016-07-21
+    quotes:
+      - text: "We transpose batch normalization into layer normalization by computing the mean and variance used for normalization from all of the summed inputs to the neurons in a layer on a single training case."
+        location: "Section 3 - Layer Normalization"
+
+  - id: src-003
+    type: secondary
+    title: "The Illustrated Transformer"
+    authors: ["Jay Alammar"]
+    url: "https://jalammar.github.io/illustrated-transformer/"
+    accessed: 2025-02-10
+    published: 2018-06-27
+
+topics:
+  - transformers
+  - architecture
+  - ai-fundamentals
+
+confidence: high
+verified: false
+verified_by: unverified
+verification_notes: "AI-assisted draft; quotes sourced from papers but need human verification against originals"
+
+ai_metadata:
+  model: claude-opus-4-6
+  generation_date: 2025-02-10
+  reviewed_by: pending
+---
+
+# Transformer Architecture Overview
+
+## Overview
+
+The Transformer is a neural network architecture "based solely on attention mechanisms, dispensing with recurrence and convolutions entirely" [src-001]. Introduced by Vaswani et al. in 2017, it replaced the dominant RNN/LSTM paradigm for sequence modeling and became the foundation for virtually all modern large language models.
+
+## The Original Encoder-Decoder Structure
+
+The original Transformer has two halves [src-001]:
+
+- **Encoder**: "maps an input sequence of symbol representations to a sequence of continuous representations"
+- **Decoder**: "generates an output sequence of symbols one element at a time"
+
+This was designed for sequence-to-sequence tasks like machine translation. Modern LLMs typically use only the decoder (GPT-style) or only the encoder (BERT-style) - see [Modern Transformer Variants](modern-variants.md).
+
+## Building Blocks
+
+### Token Embeddings
+
+Raw input (text) is first tokenized into subword units, then each token is mapped to a dense vector via a learned embedding table. These vectors are the model's internal representation of tokens.
+
+### Positional Encoding
+
+"Since our model contains no recurrence and no convolution, in order for the model to make use of the order of the sequence, we must inject some information about the relative or absolute position of the tokens in the sequence" [src-001].
+
+The original paper used fixed sinusoidal functions:
+
+```
+PE(pos, 2i)   = sin(pos / 10000^(2i/d_model))
+PE(pos, 2i+1) = cos(pos / 10000^(2i/d_model))
+```
+
+These are added to the token embeddings before entering the model. The sinusoidal approach was chosen because it allows the model to generalize to sequence lengths not seen during training. Modern models often use learned positional embeddings or rotary position embeddings (RoPE) instead.
+
+### The Encoder Block
+
+Each encoder layer contains two sub-layers:
+
+1. **Multi-head self-attention** - each token attends to all other tokens (see [Attention Mechanism](attention-mechanism.md))
+2. **Feed-forward network (FFN)** - a position-wise fully connected network applied independently to each token: `FFN(x) = max(0, xW₁ + b₁)W₂ + b₂`
+
+Both sub-layers use **residual connections** and **layer normalization**: "We employ a residual connection around each of the two sub-layers, followed by layer normalization" [src-001]. The pattern is:
+
+```
+output = LayerNorm(x + SubLayer(x))
+```
+
+### The Decoder Block
+
+Each decoder layer has three sub-layers:
+
+1. **Masked multi-head self-attention** - same as encoder, but with a causal mask preventing attention to future positions (critical for autoregressive generation)
+2. **Multi-head cross-attention** - queries from decoder, keys/values from encoder output
+3. **Feed-forward network** - same structure as encoder
+
+Again, each sub-layer has residual connections and layer normalization.
+
+### Layer Normalization
+
+Layer normalization (LayerNorm) normalizes activations across the feature dimension for each individual input, unlike batch normalization which normalizes across the batch. Ba et al. compute "the mean and variance used for normalization from all of the summed inputs to the neurons in a layer on a single training case" [src-002].
+
+This makes training more stable by keeping activations in a consistent range regardless of batch size. A practical detail: modern implementations often use **Pre-LN** (normalize before the sub-layer) rather than the original **Post-LN** (normalize after), as Pre-LN is easier to train at large scale.
+
+### Output Head
+
+For language modeling, the decoder's output vectors are projected back to vocabulary size via a linear layer, then softmax produces a probability distribution over the next token.
+
+## Key Design Properties
+
+### Parallelism
+
+Unlike RNNs that process tokens sequentially, transformers process all tokens simultaneously during training. This enables massive GPU parallelism and is a primary reason transformers scale so well.
+
+### Depth Through Stacking
+
+The original Transformer used N=6 encoder and decoder layers. Modern models stack far more: GPT-3 uses 96 layers, Llama 2 70B uses 80 layers. Each additional layer allows the model to build more abstract representations.
+
+### Parameter Count
+
+Most parameters live in two places:
+- **Attention projections**: The Q, K, V, and output projection matrices in each attention layer
+- **FFN layers**: The two weight matrices in each feed-forward block (these often contain ~2/3 of total parameters)
+- **Embedding tables**: The token embedding matrix (shared with the output projection in many models)
+
+## The Original Scale
+
+Vaswani et al.'s "big" model:
+- d_model = 1024 (hidden dimension)
+- 16 attention heads
+- 6 layers each for encoder and decoder
+- ~213M parameters
+- Trained on 8 P100 GPUs for 3.5 days
+
+For comparison, GPT-4 is estimated at over 1 trillion parameters. The architecture has scaled over four orders of magnitude.
+
+## Further Reading
+
+- [Attention Is All You Need](https://arxiv.org/abs/1706.03762) - The foundational paper [src-001]
+- [The Illustrated Transformer](https://jalammar.github.io/illustrated-transformer/) - Excellent visual guide [src-003]
+- [The Attention Mechanism](attention-mechanism.md) - Deep dive on attention
+- [Modern Transformer Variants](modern-variants.md) - How the architecture has evolved


### PR DESCRIPTION
## Summary

- Populates all three previously-empty topic directories with foundational content
- Adds 9 articles totaling ~1,870 lines across transformers, agents, and local-inference
- All articles follow the PROVENANCE.md frontmatter schema with cited primary sources and exact quotes
- Articles are cross-linked within their topic areas

### transformers/
- **attention-mechanism.md** — Bahdanau attention, scaled dot-product, multi-head, self vs. cross attention
- **transformer-architecture.md** — Encoder-decoder structure, positional encoding, layer norm, the full stack
- **modern-variants.md** — Decoder-only (GPT), encoder-only (BERT), MoE, RoPE, SwiGLU, FlashAttention, GQA

### agents/
- **agent-architectures.md** — Core agent loop, CoT, ReAct, Tree of Thoughts, Reflexion, planning patterns
- **tool-use-function-calling.md** — Tool use protocol, Toolformer, function calling APIs, MCP, evaluation
- **multi-agent-systems.md** — Coordination patterns, frameworks (AutoGen, CrewAI, LangGraph), tradeoffs

### local-inference/
- **quantization-methods.md** — GPTQ, AWQ, GGUF, bitsandbytes, practical sizing guidelines
- **inference-engines.md** — llama.cpp, Ollama, vLLM, SGLang, MLX, comparison table
- **hardware-and-optimization.md** — Memory equation, GPU/Apple Silicon/CPU tradeoffs, speculative decoding, KV cache

## Review notes

All articles are marked `verified: false` and `curation_type: ai_assisted`. Quotes should be verified against original papers before marking as verified.

Addresses #1

## Test plan

- [ ] Verify YAML frontmatter parses correctly on all 9 articles
- [ ] Spot-check quoted text against source papers
- [ ] Confirm cross-links between articles resolve correctly
- [ ] Review content accuracy and completeness