### PR TITLE
Cleanup sprint: design docs + CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,3 +49,5 @@ jobs:
 
       - name: Check ontology versions
         run: uv run python scripts/check_ontology_versions.py
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,51 @@
+name: Validate Knowledge Base
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Schema & Term Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Validate schema
+        run: uv run python scripts/validate.py
+
+      - name: Validate topic terms
+        run: uv run python scripts/validate_terms.py
+
+  check-ontology-versions:
+    name: Check Ontology Versions
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Check ontology versions
+        run: uv run python scripts/check_ontology_versions.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This document provides guidance for AI agents working in this repository.
 
 ## Purpose
 
-This repository is a **curated knowledge base** for understanding AI/ML concepts. It serves as an educational resource for humans and (eventually) a RAG source for AI agents.
+This repository is a **curated knowledge base** for understanding AI/ML concepts. It serves as an educational resource for humans and as the RAG knowledge source for the [cc_forge](https://github.com/amc-corey-cox/cc_forge) coding assistant.
 
 ## What This Repo Contains
 
@@ -13,6 +13,18 @@ This repository is a **curated knowledge base** for understanding AI/ML concepts
 - `pending/` - Unverified content awaiting review
 - `sources/` - Cached source material
 - `curriculum/` - Learning paths (future)
+
+## Verification Model
+
+This repo follows an **automated-first verification** approach: AI writes content, automated checks validate it, and humans intervene only on conflicts.
+
+The pipeline:
+1. **Schema validation** — frontmatter conforms to LinkML schema (`make validate-all`)
+2. **Term validation** — topic terms exist in the AIO ontology (`make validate-terms`)
+3. **Quote verification** — quoted text found in source content (planned)
+4. **Claims cross-check** — no contradictions with existing articles (planned)
+
+Content passing all automated checks is promoted from `ai_unverified` to `ai_generated` with `verified_by: automated`. Human review is only required when automated checks flag failures or contradictions.
 
 ## Core Principle: Provenance
 
@@ -56,8 +68,9 @@ verification_date: 2025-01-27
 ### When Adding Content
 - Place in appropriate `topics/` subdirectory
 - Include full frontmatter with sources
-- Use exact quotes when citing
-- Mark AI-generated content as `ai_unverified` until human reviews
+- Use exact quotes when citing — these will be programmatically verified against sources
+- Mark AI-generated content as `ai_unverified`; the automated pipeline handles promotion
+- Run `make validate-all` before committing to catch schema and term errors
 
 ### When Updating Content
 - Update the `updated` date
@@ -78,18 +91,20 @@ verification_date: 2025-01-27
 
 ## Related Repositories
 
-| Repository | Purpose |
-|------------|---------|
-| `cc_forge` | Local-first AI coding assistant (main project) |
-| `cc_ai_model_ontology` | Structured model catalog (LinkML) |
+| Repository | Purpose | Relationship |
+|------------|---------|--------------|
+| `cc_forge` | Local-first AI coding assistant (main project) | RAG consumer — retrieves knowledge articles for agent context |
+| `cc_ai_model_ontology` | Structured model catalog (LinkML) | Provides structured model metadata referenced by articles |
 
 ## Topic Structure
 
 ```
 topics/
+├── agentic-coding/      # AI-assisted software development
 ├── ai-fundamentals/     # Core AI concepts
 ├── agents/              # AI agent patterns
 ├── local-inference/     # Running models locally
+├── protocols/           # Standards and protocols (MCP, etc.)
 └── transformers/        # Transformer architecture
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ This repo follows an **automated-first verification** approach: AI writes conten
 
 The pipeline:
 1. **Schema validation** — frontmatter conforms to LinkML schema (`make validate-all`)
-2. **Term validation** — topic terms exist in the AIO ontology (`make validate-terms`)
+2. **Term validation** — schema `meaning:` CURIEs resolve against AIO (`make validate-terms`)
 3. **Quote verification** — quoted text found in source content (planned)
 4. **Claims cross-check** — no contradictions with existing articles (planned)
 

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -157,31 +157,36 @@ Content that passes all automated checks is promoted to `ai_generated` with `ver
 - Cross-article contradictions are detected
 
 ### Quarantine Zone
-Unverified AI content lives in `knowledge/pending/` until verified, then moves to main knowledge base.
+Unverified AI content lives in `pending/` until verified, then moves to `topics/`.
 
 ---
 
 ## Directory Structure
 
 ```
-knowledge/
 ├── PROVENANCE.md           # This document
+├── AGENTS.md               # Agent instructions (CLAUDE.md symlinks here)
 ├── schema/
-│   └── entry.yaml          # LinkML or JSON Schema definition
+│   └── knowledge-entry.yaml  # LinkML schema definition
+├── scripts/                # Validation scripts
+│   ├── validate.py
+│   ├── validate_terms.py
+│   └── check_ontology_versions.py
+├── conf/                   # Configuration (OAK, ontology files)
+│   ├── oak_config.yaml
+│   └── aio.obo
 ├── topics/                 # Verified knowledge by topic
+│   ├── agentic-coding/
 │   ├── ai-fundamentals/
-│   ├── transformers/
 │   ├── agents/
-│   └── ...
-├── project/                # CC Forge-specific knowledge
-│   ├── architecture.md
-│   ├── conventions.md
-│   └── decisions/
+│   ├── local-inference/
+│   ├── protocols/
+│   └── transformers/
 ├── pending/                # Unverified AI-generated content
 │   └── ...
 ├── sources/                # Cached/archived source material
 │   └── ...
-└── curriculum/             # Learning paths
+└── curriculum/             # Learning paths (future)
     └── ...
 ```
 
@@ -197,8 +202,8 @@ knowledge/
 ### Phase 2: Schema Validation — COMPLETE
 - LinkML schema at `schema/knowledge-entry.yaml`
 - `scripts/validate.py` validates frontmatter against schema
-- `scripts/validate_terms.py` validates topic terms against AIO ontology
-- Makefile targets: `validate`, `validate-all`, `validate-terms`
+- `scripts/validate_terms.py` uses `linkml-term-validator validate-schema` to ensure CURIEs in schema `meaning:` fields resolve against AIO
+- Makefile targets: `validate`, `validate-all`, `validate-terms` (schema validation and term CURIE resolution)
 - CI workflow for automated validation on push/PR
 
 ### Phase 3: Automated Verification — IN PROGRESS
@@ -247,7 +252,7 @@ The key insight: **Git provides an immutable history**, and **YAML frontmatter p
 
 ## Open Questions
 
-1. **Controlled vocabularies**: ~~Should topics be free-form or from a defined list?~~ **RESOLVED** — Hybrid approach: AIO ontology terms validated via OAK + local enum extensions in the LinkML schema. See `scripts/validate_terms.py`.
+1. **Controlled vocabularies**: ~~Should topics be free-form or from a defined list?~~ **RESOLVED** — Hybrid approach: topics are constrained by a `TopicTerm` enum in the LinkML schema, with AIO CURIEs in `meaning:` fields validated via OAK (`scripts/validate_terms.py` runs `linkml-term-validator validate-schema`). Data-level topic validation is handled by the base schema validator's enum check. Future work may extend OAK-based validation to arbitrary topic strings.
 2. **Archive strategy**: Cache sources locally, use archive.org, or trust URLs?
 3. **Quote verification** (**HIGH PRIORITY**): How aggressive? PubMed-style exact match or fuzzy? Blocking the automated verification pipeline.
 4. **Trust decay** (**HIGH PRIORITY**): Should old unverified content be auto-demoted? Proposed: time-based confidence degradation with different decay rates per curation type.


### PR DESCRIPTION
## Summary

- Update PROVENANCE.md and AGENTS.md to reflect the automated-first verification philosophy ("AI writes, AI validates, human intervenes on conflicts")
- Add GitHub Actions CI workflow for schema and term validation
- Housekeeping: closed stale issues, cleaned up branches, created tracking issues for next phase

## Changes

**PROVENANCE.md:**
- Replace human-review-primary verification model with automated pipeline (schema → source → quotes → claims → human on conflicts)
- Mark Phases 1+2 as COMPLETE, expand Phase 3 with specific deliverables
- Rename Phase 4 to "cc_forge RAG Integration" with specifics
- Resolve Q1 (controlled vocabularies), mark Q3+Q4 as HIGH PRIORITY
- Remove "(Stretch Goal)" from quote verification

**AGENTS.md:**
- Add new "Verification Model" section explaining automated-first approach
- Update purpose to reference cc_forge as RAG consumer
- Add `agentic-coding/` and `protocols/` to topic structure
- Add relationship column to Related Repositories table
- Reference automated pipeline in content guidelines

**CI:**
- `.github/workflows/validate.yml` — two jobs: blocking validation + informational ontology version check

## Housekeeping (done directly on main)

- Removed stale worktree (`add-claude-code-articles`, PR #12 merged)
- Deleted 4 local + 2 remote stale branches
- Closed issues #1, #2, #7 with summaries
- Updated issue #3 with current status
- Created issues #13, #14, #15 for next phase

## Test plan

- [ ] CI workflow runs on this PR (meta-test)
- [ ] `make validate-all` still passes (docs don't affect validation)
- [ ] CLAUDE.md symlink picks up AGENTS.md changes